### PR TITLE
Fix React test cleanup

### DIFF
--- a/src/App.test.js
+++ b/src/App.test.js
@@ -5,4 +5,5 @@ import App from './App';
 it('renders without crashing', () => {
   const div = document.createElement('div');
   ReactDOM.render(<App />, div);
+  ReactDOM.unmountComponentAtNode(div);
 });


### PR DESCRIPTION
## Summary
- ensure React test unmounts component after rendering

## Testing
- `npm test` *(fails: cross-env not found)*

------
https://chatgpt.com/codex/tasks/task_e_6849a76a7b4c832a8e0646a66c357267